### PR TITLE
remove unnecessary menu separator

### DIFF
--- a/private/popup-menu.rkt
+++ b/private/popup-menu.rkt
@@ -25,8 +25,8 @@
            [label "Workspace Manager"]
            [parent workspaces]
            [callback (λ (c e) (send (new workspace-manager%) show #t))])
-      (new separator-menu-item% [parent workspaces])
-      (when prefs
+      (when (not (empty? prefs))
+        (new separator-menu-item% [parent workspaces])
         (for ([i prefs])
           (new menu-item% [label (first i)]
                [parent workspaces][callback (λ (c e)


### PR DESCRIPTION
There should be no separator when Workspaces is empty

## Before
![Screenshot_20190316_232904](https://user-images.githubusercontent.com/17017672/54477509-81406300-4843-11e9-9fc8-ae25bc5d2133.png)

## After
![Screenshot_20190316_233022](https://user-images.githubusercontent.com/17017672/54477510-869dad80-4843-11e9-8581-f969d7fb7353.png)
