### PR TITLE
add Change to the Common Directory

### DIFF
--- a/private/path-helpers.rkt
+++ b/private/path-helpers.rkt
@@ -1,6 +1,7 @@
 #lang racket
 (provide path-/string new-file-dialog delete-file-and-directory
-         process/safe binary-file?)
+         process/safe binary-file?
+         paths-common-prefix)
 (require rackunit racket/gui syntax/parse/define (for-syntax racket/syntax)
          "contents.rkt" "info-instructor.rkt"
          )
@@ -39,6 +40,19 @@
           (delete-file-and-directory/recur i))
         (delete-directory path))
       ))
+
+;; paths-common-prefix : [Listof Path] -> Path | #f
+;; Produces the common ancestor directory of the given paths,
+;; or #f if the list is empty.
+(define (paths-common-prefix ps)
+  (match ps
+    ['() #f]
+    [(list p) p]
+    [(cons p0 rst)
+     (path->directory-path
+      (apply build-path
+             (for/fold ([common (explode-path p0)]) ([p (in-list rst)])
+               (take-common-prefix common (explode-path p)))))]))
 
 (define (create-new-file path name content)
   (define new-name (if (file-exists? path)

--- a/private/popup-menu.rkt
+++ b/private/popup-menu.rkt
@@ -46,6 +46,8 @@
     (define-menu-item change-to-this-directory "Change to this Directory")
     (define-menu-item change-to-the-directory-of-current-file
       "Change to the Directory of Current File")
+    (define-menu-item change-to-the-common-directory
+      "Change to the Common Directory")
     (define-menu-item refresh "Refresh")
     (new separator-menu-item% [parent this])
     (define-menu-item new-file "New")

--- a/tool.rkt
+++ b/tool.rkt
@@ -173,6 +173,13 @@
                                 (thunk 
                                  (define d (send (send this get-current-tab) get-directory))
                                  (change-to-directory d))]
+                               [change-to-the-common-directory-callback
+                                (thunk
+                                 (define d
+                                   (paths-common-prefix
+                                    (for/list ([t (in-list (send this get-tabs))])
+                                      (send t get-directory))))
+                                 (when d (change-to-directory d)))]
                                [git-pull-callback
                                 (thunk
                                  (define item (send *files get-selected))


### PR DESCRIPTION
Closes #39 by adding a popup-menu option `Change to the Common Directory` which changes to the common ancestor directory of all of the current tabs.