### PR TITLE
Improvements on scrolling and auto-refreshing

### DIFF
--- a/hierlist/hierlist-unit.rkt
+++ b/hierlist/hierlist-unit.rkt
@@ -16,16 +16,19 @@
       (define picture-cache #f)
       (define/public (set-word-filter something)
         (set! word-filter something)
-        (set! picture-cache (pict->bitmap (inset (frame
-                                                  (inset (blue (text word-filter 'system 13)) 3)
-                                                  #:line-width 1) 1)
-                                          #:make-bitmap
-                                          (λ (w h)
-                                            (make-object bitmap% w h #f #f 2.0))))
+        (set! picture-cache
+              (if (string=? something "") #f
+                  (pict->bitmap (inset (frame
+                                        (inset (blue (text word-filter 'system 13)) 3)
+                                        #:line-width 1) 1)
+                                #:make-bitmap
+                                (λ (w h)
+                                  (make-object bitmap% w h #f #f 2.0)))))
         (invalidate-bitmap-cache 0.0 0.0 'display-end 'display-end))
       (define/override (after-scroll-to)
-        (invalidate-bitmap-cache 0.0 0.0 'display-end 'display-end)
-        (super after-scroll-to))
+        (super after-scroll-to)
+        (when picture-cache
+          (invalidate-bitmap-cache 0.0 0.0 'display-end 'display-end)))
       (define/public (get-word-filter) word-filter)
       (define/override (on-paint before? dc left top right bottom dx dy draw-caret)
         (when (and (not (string=? "" word-filter))

--- a/private/gui-helpers.rkt
+++ b/private/gui-helpers.rkt
@@ -123,11 +123,10 @@
       (define c (send ev get-key-code))
       (define old (send (get-editor) get-word-filter))
       (match c
-        [#\backspace (send (get-editor) set-word-filter
-                           (if (string=? old "")
-                               ""
-                               (substring old 0 (- (string-length old) 1))))
-                     (update-files!)]
+        [#\backspace (unless (string=? old "")
+                       (send (get-editor) set-word-filter
+                             (substring old 0 (- (string-length old) 1)))
+                       (update-files!))]
         [(or (? (conjoin char? char-graphic?)) #\space)
          (send (get-editor) set-word-filter (string-append old (string c)))
          (update-files!)]

--- a/private/gui-helpers.rkt
+++ b/private/gui-helpers.rkt
@@ -133,13 +133,18 @@
          (update-files!)]
         [else (void)])
       (super on-char ev))
+
+    (define/private (may-begin-edit-sequence)
+      (define e (get-editor))
+      (unless (send e in-edit-sequence?)
+        (send e begin-edit-sequence)))
     
     (define/public (update-files! [changed-paths #f])
       (define e (get-editor))
       (define ad (send e get-admin))
       (define filter-types (preferences:get 'files-viewer:filter-types))
-      (suspend-flush)
-      (send e begin-edit-sequence)
+      (when (or (not changed-paths) (send e in-edit-sequence?))
+        (send e begin-edit-sequence))
       (define-values (x y w h) (values (box 0) (box 0) (box 0) (box 0)))
       (send ad get-view x y w h)
       
@@ -165,11 +170,9 @@
            (update-directory! item (send item user-data) (or filter-types '()) #t))
          (when (member the-dir changed-paths)
            (update-directory! this the-dir (or filter-types '()) #t))])
-      
-      (send e end-edit-sequence)
-      (send ad scroll-to (unbox x) (unbox y) (unbox w) (unbox h) #f)
-      (resume-flush)
-      (refresh))
+      (when (send e in-edit-sequence?)
+        (send e end-edit-sequence))
+      (send ad scroll-to (unbox x) (unbox y) (unbox w) (unbox h) #t))
 
     (define/public (set-dir! dir)
       (set! the-dir dir))
@@ -250,21 +253,25 @@
                    [(set-member? neo-dirs p)
                     (hash-set h p item)]
                    [else
+                    (may-begin-edit-sequence)
                     (send parent delete-item item)
                     h])
                  (cond
                    [(set-member? neo-files p)
                     (hash-set h p item)]
                    [else
+                    (may-begin-edit-sequence)
                     (send parent delete-item item)
                     h]))))
            
          (for ([d (in-list dirs)])
            (unless (hash-has-key? path+items (build d))
+             (may-begin-edit-sequence)
              ((add-item! #t) d)))
            
          (for ([f (in-list regular-files)])
            (unless (hash-has-key? path+items (build f))
+             (may-begin-edit-sequence)
              ((add-item! #f) f)))]))
 
     (define/override (on-double-select i)


### PR DESCRIPTION
1. Avoid refreshing while the file tree doesn't actually change. This should be useful when `(system-type 'fs-change)` contains `file-level`.
2. Avoid invalidating the bitmap cache when the word filter is inactive.