### PR TITLE
Add file filter to remove files with tilde suffix

### DIFF
--- a/private/file-filters.rkt
+++ b/private/file-filters.rkt
@@ -17,6 +17,10 @@
                               [parent panel]
                               [label "Hide dot prefix files and directories."]
                               [value (preferences:get 'files-viewer:filter-types3)]))
+      (define hide~files (new check-box% 
+                              [parent panel]
+                              [label "Hide tilde suffix files and directories."]
+                              [value (preferences:get 'files-viewer:filter-types4)]))
       (define choice (new radio-box% [choices '("Hide these files."
                                                 "Show these files.")]
                           [label ""]
@@ -39,6 +43,7 @@
                                   (preferences:set 'files-viewer:filter-types (string-split (send types get-value) " "))
                                   (preferences:set 'files-viewer:filter-types2 (= 1 (send choice get-selection)))
                                   (preferences:set 'files-viewer:filter-types3 (send hide.files get-value))
+                                  (preferences:set 'files-viewer:filter-types4 (send hide~files get-value))
                                   (send this show #f))]))
       
       (send types focus)

--- a/private/file-filters.rkt
+++ b/private/file-filters.rkt
@@ -1,7 +1,8 @@
 #lang racket
 (require racket/gui
          framework
-         framework/preferences)
+         framework/preferences
+         "gui-helpers.rkt")
 (provide filter-dialog)
 (define (filter-dialog dparent)
   (define filter-dialog%
@@ -19,7 +20,7 @@
                               [value (preferences:get 'files-viewer:filter-types3)]))
       (define hide~files (new check-box% 
                               [parent panel]
-                              [label "Hide tilde suffix files and directories."]
+                              [label (format "Hide backup files (ending in ~a)." (backup-file-suffix))]
                               [value (preferences:get 'files-viewer:filter-types4)]))
       (define choice (new radio-box% [choices '("Hide these files."
                                                 "Show these files.")]
@@ -27,7 +28,7 @@
                           [parent panel]
                           [selection (if (preferences:get 'files-viewer:filter-types2)
                                          1 0)]))
-      (new message% [label "Files types (such as \".bak .zo\"):"] [parent panel])
+      (new message% [label "Files types (such as \".dep .zo\"):"] [parent panel])
       (define types (new text-field%
                          [label ""]
                          [parent panel]

--- a/private/gui-helpers.rkt
+++ b/private/gui-helpers.rkt
@@ -1,6 +1,6 @@
 #lang racket
 (require "../hierlist/hierlist.rkt" racket/gui framework racket/runtime-path file/glob pict)
-(provide directory-list% my-horizontal-dragable%)
+(provide backup-file-suffix directory-list% my-horizontal-dragable%)
 
 (define my-horizontal-dragable%
   (class panel:horizontal-dragable%
@@ -111,6 +111,11 @@
   (cond [(xor dir? p2) dir?]
         [else (path<? path (send y user-data))]))
 
+(define (backup-file-suffix)
+  (match (system-type 'os)
+    ['windows ".bak"]
+    [_ "~"]))
+
 (define directory-list%
   (class hierarchical-list%
     (init-field [select-callback void]
@@ -204,8 +209,10 @@
         (when (and (or is-directory
                        (not (xor (preferences:get 'files-viewer:filter-types2)
                                  (ormap (λ (x) (path-has-extension? i x)) filter-types))))
-                   (not (and (preferences:get 'files-viewer:filter-types3) (string-prefix? (path->string i) ".")))
-                   (not (and (preferences:get 'files-viewer:filter-types4) (string-suffix? (path->string i) "~")))
+                   (not (and (preferences:get 'files-viewer:filter-types3)
+                             (string-prefix? (path->string i) ".")))
+                   (not (and (preferences:get 'files-viewer:filter-types4)
+                             (string-suffix? (path->string i) (backup-file-suffix))))
                    (or is-directory
                        cute-syntax-enabled?
                        (not compiled-regexp)

--- a/private/gui-helpers.rkt
+++ b/private/gui-helpers.rkt
@@ -205,6 +205,7 @@
                        (not (xor (preferences:get 'files-viewer:filter-types2)
                                  (ormap (λ (x) (path-has-extension? i x)) filter-types))))
                    (not (and (preferences:get 'files-viewer:filter-types3) (string-prefix? (path->string i) ".")))
+                   (not (and (preferences:get 'files-viewer:filter-types4) (string-suffix? (path->string i) "~")))
                    (or is-directory
                        cute-syntax-enabled?
                        (not compiled-regexp)

--- a/tool.rkt
+++ b/tool.rkt
@@ -22,6 +22,9 @@
                   (preferences:set-default 'files-viewer:is-show
                                            #t
                                            boolean?)
+                  (preferences:set-default 'files-viewer:filter-types4
+                                           #t
+                                           boolean?)
                   (preferences:set-default 'files-viewer:filter-types3
                                            #t
                                            boolean?)


### PR DESCRIPTION
On my platform (Ubuntu Linux) any file I edit with DrRacket gets duplicated with a tilde (`~`) at the end, for example:

```
$ ls -l tool.*
-rw-rw-r-- 1 marc marc 16188 Jun 17 20:55 tool.rkt
-rw-rw-r-- 1 marc marc 16188 Jun 17 20:47 tool.rkt~
```

I've added to the filter dialog and preferences a choice to filter out these files.

Since I don't have a Mac or Windows box I don't know if this is a common affliction. If not, this code should probably be extended to avoid the choice for other platforms. On the other hand, it shouldn't break anything and the prefix period preference probably only applies to Linux so maybe it doesn't matter.