### PR TITLE
Add Workspace 'Use current directory button'

### DIFF
--- a/private/dir-control.rkt
+++ b/private/dir-control.rkt
@@ -11,6 +11,7 @@
 (provide dir-control% path-alist)
 ;;
 
+;; this function seems to never be used anywhere 2023-06-18 madkins23
 (define (my-directory-list dir #:hidden [hidden #t])
   (if (not hidden)
       (filter (λ (p) (if (equal? (string-ref (path->string p) 0) #\.) #f #t))

--- a/private/dir-control.rkt
+++ b/private/dir-control.rkt
@@ -11,13 +11,6 @@
 (provide dir-control% path-alist)
 ;;
 
-;; this function seems to never be used anywhere 2023-06-18 madkins23
-(define (my-directory-list dir #:hidden [hidden #t])
-  (if (not hidden)
-      (filter (λ (p) (if (equal? (string-ref (path->string p) 0) #\.) #f #t))
-              (directory-list dir))
-      (directory-list dir)))
-
 ;; list the full paths above this one
 (define (parent-paths path)
   (define-values (base name dir) (split-path path))

--- a/private/gui-helpers.rkt
+++ b/private/gui-helpers.rkt
@@ -203,7 +203,9 @@
 
       (define-values (dirs regular-files)
         (partition (λ (p) (directory-exists? (build p)))
-                   (sort files path<?)))
+                   (map string->path
+                        (sort (map path->string files)
+                              string-ci<?))))
 
       (define ((add-item! is-directory) i)
         (when (and (or is-directory

--- a/private/popup-menu.rkt
+++ b/private/popup-menu.rkt
@@ -154,49 +154,43 @@
     ; enable or dispable the OK button if appropriate.
     (define/private (enable-ok-button)
       (let ([path-string (send path-text get-value)])
-        (when (non-empty-string? path-string)
-          (send ok-button enable
-                (if (directory-exists? (string->path path-string))
-                    #t #f)))))
+        (send ok-button enable
+              (if (and (non-empty-string? path-string)
+                       (directory-exists? (string->path path-string)))
+                  #t #f))))
     
-    (define p2 (new horizontal-panel% [parent this]))
+    (define p2 (new vertical-panel% [parent this]))
+    (define p2txt (new horizontal-panel% [parent p2] [alignment '(center bottom)]))
     (new message%
-         [parent p2]
+         [parent p2txt]
          [label "Path:"]
          [stretchable-width #f]
          [min-width 45])
-    (define path-text (new text-field% [parent p2] [label ""] [callback (λ (c e) (enable-ok-button))]))
+    (define path-text (new text-field% [parent p2txt] [label ""] [callback (λ (c e) (enable-ok-button))]))
     
-    (define bp (new horizontal-panel%
-                    [parent this]
-                    [alignment '(right bottom)]
-                    [stretchable-height #f]))
-    (define dirp (new horizontal-panel%
-                    [parent bp]
-                    [alignment '(left bottom)]
-                    [stretchable-height #f]))
+    (define p2dir (new horizontal-panel% [parent p2] [alignment '(right top)]))
     (define current-button (new button%
-                                [parent dirp]
-                                [label "Current directory"]
+                                [parent p2dir]
+                                [label "Use current directory"]
                                 [callback (λ (c e)
                                             (send path-text set-value
                                                   (preferences:get 'files-viewer:directory))
                                             (enable-ok-button))]))
     (define dir-button (new button%
-                            [parent dirp]
+                            [parent p2dir]
                             [label "Select the directory"]
                             [callback (λ (c e)
                                         (define res (get-directory))
                                         (when res
                                           (send path-text set-value (path->string res))
                                           (enable-ok-button)))]))
-    (define dop (new horizontal-panel%
-                    [parent bp]
+    (define bp (new horizontal-panel%
+                    [parent this]
                     [alignment '(right bottom)]
                     [stretchable-height #f]))
-    (define cancel-button (new button% [parent dop] [label "Cancel"] [callback (λ (c e) (send this show #f))]))
+    (define cancel-button (new button% [parent bp] [label "Cancel"] [callback (λ (c e) (send this show #f))]))
     (define ok-button (new button%
-                           [parent dop]
+                           [parent bp]
                            [label "OK"]
                            [enabled #f]
                            [callback (λ (c e) (define prefs (preferences:get 'files-viewer:workspaces))
@@ -314,3 +308,6 @@
 
 (module+ test1
   (new files-popup-menu% [change-the-directory-callback void]))
+
+(module+ test2
+  (send (new new-workspace%) show #t))

--- a/private/popup-menu.rkt
+++ b/private/popup-menu.rkt
@@ -150,30 +150,55 @@
          [min-width 45])
     (define name-text (new text-field% [parent p1] [label ""]))
 
+    ; Check to see if the path-text field contains a valid directory path and
+    ; enable or dispable the OK button if appropriate.
+    (define/private (enable-ok-button)
+      (let ([path-string (send path-text get-value)])
+        (when (non-empty-string? path-string)
+          (send ok-button enable
+                (if (directory-exists? (string->path path-string))
+                    #t #f)))))
+    
     (define p2 (new horizontal-panel% [parent this]))
     (new message%
          [parent p2]
          [label "Path:"]
          [stretchable-width #f]
          [min-width 45])
-    (define path-text (new text-field% [parent p2] [label ""]))
+    (define path-text (new text-field% [parent p2] [label ""] [callback (λ (c e) (enable-ok-button))]))
     
     (define bp (new horizontal-panel%
                     [parent this]
                     [alignment '(right bottom)]
                     [stretchable-height #f]))
-
+    (define dirp (new horizontal-panel%
+                    [parent bp]
+                    [alignment '(left bottom)]
+                    [stretchable-height #f]))
+    (define current-button (new button%
+                                [parent dirp]
+                                [label "Current directory"]
+                                [callback (λ (c e)
+                                            (send path-text set-value
+                                                  (preferences:get 'files-viewer:directory))
+                                            (enable-ok-button))]))
     (define dir-button (new button%
-                            [parent bp]
+                            [parent dirp]
                             [label "Select the directory"]
                             [callback (λ (c e)
                                         (define res (get-directory))
                                         (when res
-                                          (send path-text set-value (path->string res))))]))
-    (define cancel-button (new button% [parent bp] [label "Cancel"] [callback (λ (c e) (send this show #f))]))
+                                          (send path-text set-value (path->string res))
+                                          (enable-ok-button)))]))
+    (define dop (new horizontal-panel%
+                    [parent bp]
+                    [alignment '(right bottom)]
+                    [stretchable-height #f]))
+    (define cancel-button (new button% [parent dop] [label "Cancel"] [callback (λ (c e) (send this show #f))]))
     (define ok-button (new button%
-                           [parent bp]
+                           [parent dop]
                            [label "OK"]
+                           [enabled #f]
                            [callback (λ (c e) (define prefs (preferences:get 'files-viewer:workspaces))
                                        (preferences:set 'files-viewer:workspaces
                                                         (append prefs (list (list (send name-text get-value)

--- a/private/popup-menu.rkt
+++ b/private/popup-menu.rkt
@@ -189,7 +189,6 @@
                     [parent this]
                     [alignment '(right bottom)]
                     [stretchable-height #f]))
-    (define cancel-button (new button% [parent bp] [label "Cancel"] [callback (λ (c e) (send this show #f))]))
     (define ok-button (new button%
                            [parent bp]
                            [label "OK"]
@@ -199,6 +198,7 @@
                                                         (append prefs (list (list (send name-text get-value)
                                                                                   (send path-text get-value)))))
                                        (send this show #f))]))
+    (define cancel-button (new button% [parent bp] [label "Cancel"] [callback (λ (c e) (send this show #f))]))
     (define/override (on-subwindow-char recv ev)
       (when (equal? (send ev get-key-code) #\return)
         (send ok-button command (make-object control-event% 'button (current-milliseconds))))

--- a/private/popup-menu.rkt
+++ b/private/popup-menu.rkt
@@ -148,19 +148,20 @@
          [label "Name:"]
          [stretchable-width #f]
          [min-width 45])
-    (define name-text (new text-field% [parent p1] [label ""]))
+    (define name-text (new text-field% [parent p1] [label ""] [callback (λ (c e) (enable-ok-button))]))
 
-    ; Check to see if the path-text field contains a valid directory path and
-    ; enable or dispable the OK button if appropriate.
+    ; Check to see if the name-text field contains a non-empty string and
+    ; the path-text field contains a valid directory path.
+    ; Enable or disable the OK button as appropriate.
     (define/private (enable-ok-button)
       (let ([path-string (send path-text get-value)])
         (send ok-button enable
-              (if (and (non-empty-string? path-string)
-                       (directory-exists? (string->path path-string)))
-                  #t #f))))
+              (and (non-empty-string? (string-trim (send name-text get-value)))
+                   (non-empty-string? path-string)
+                   (directory-exists? (string->path path-string))))))
     
     (define p2 (new vertical-panel% [parent this]))
-    (define p2txt (new horizontal-panel% [parent p2] [alignment '(center bottom)]))
+    (define p2txt (new horizontal-panel% [parent p2] [stretchable-height #f]))
     (new message%
          [parent p2txt]
          [label "Path:"]
@@ -168,7 +169,7 @@
          [min-width 45])
     (define path-text (new text-field% [parent p2txt] [label ""] [callback (λ (c e) (enable-ok-button))]))
     
-    (define p2dir (new horizontal-panel% [parent p2] [alignment '(right top)]))
+    (define p2dir (new horizontal-panel% [parent p2] [alignment '(right top)] [stretchable-height #f]))
     (define current-button (new button%
                                 [parent p2dir]
                                 [label "Use current directory"]


### PR DESCRIPTION
This started with the title above, I wanted to be able to just use the `files-viewer` concept of the "current" directory without browsing through the entire directory tree when adding a new workspace.

I started by adding a button to populate the path text field. Then while I was testing it and I kept tweaking things:
* I added code to only enable the `OK` button when
  * there is some non-whitespace in the name text field and
  * the path text field contains the path of an existing directory.
* I rearranged the layout to put the path text field populating buttons closer to it.

So not all that many things but still more than I intended. If I went overboard or you hate the new layout just say so.