### PR TITLE
Directory sort

### DIFF
--- a/private/dir-control.rkt
+++ b/private/dir-control.rkt
@@ -11,6 +11,7 @@
 (provide dir-control% path-alist)
 ;;
 
+;; this function seems to never be used anywhere 2023-06-18 madkins23
 (define (my-directory-list dir #:hidden [hidden #t])
   (if (not hidden)
       (filter (λ (p) (if (equal? (string-ref (path->string p) 0) #\.) #f #t))

--- a/private/dir-control.rkt
+++ b/private/dir-control.rkt
@@ -11,13 +11,6 @@
 (provide dir-control% path-alist)
 ;;
 
-;; this function seems to never be used anywhere 2023-06-18 madkins23
-(define (my-directory-list dir #:hidden [hidden #t])
-  (if (not hidden)
-      (filter (λ (p) (if (equal? (string-ref (path->string p) 0) #\.) #f #t))
-              (directory-list dir))
-      (directory-list dir)))
-
 ;; list the full paths above this one
 (define (parent-paths path)
   (define-values (base name dir) (split-path path))

--- a/private/gui-helpers.rkt
+++ b/private/gui-helpers.rkt
@@ -203,7 +203,9 @@
 
       (define-values (dirs regular-files)
         (partition (λ (p) (directory-exists? (build p)))
-                   (sort files path<?)))
+                   (map string->path
+                        (sort (map path->string files)
+                              string-ci<?))))
 
       (define ((add-item! is-directory) i)
         (when (and (or is-directory


### PR DESCRIPTION
I noticed that the directory listing in the files viewer was sorted in a case-sensitive manner:

```
Alpha
Bravo
alpha
bravo
```
instead of a case-insensitive manner:
```
Alpha
alpha
Bravo
bravo
```
This PR implements a case-insensitive sort. It doesn't seem to affect the partitioning of items into directory and file groups. I ran it against a lot of directories on my  system and it seems to be effective and harmless.

Perhaps the current behavior is as designed or this minor fix is redundant. Perhaps the behavior should be added to the preferences for individual choice. I'm OK with adding a preference or killing the PR, it didn't take me long to do the work.

In the process I stumbled across function `my-directory-list` that is not called from anywhere in the code. It seems to be a way to filter out files that start with a period, a function that is now implemented in the `File filter` dialog. It looks like a relic so I took it out and nothing broke.