### PR TITLE
Changes the current directory when DrRacket launches.

### DIFF
--- a/private/popup-menu.rkt
+++ b/private/popup-menu.rkt
@@ -289,20 +289,33 @@
                                         (send change-current-tab-to-a-new-file-when
                                               get-selection)))]))
 
+    (define experimental-tab
+      (new vertical-panel%
+           [parent tp]))
+    
     (define is-binary-file-open
       (new check-box%
            [label "Open a known binary file in a new tab."]
-           [parent tp]
+           [parent experimental-tab]
            [value (preferences:get 'files-viewer:binary-file-open)]
            [callback (λ (c e)
                        (preferences:set 'files-viewer:binary-file-open
                                         (send is-binary-file-open get-value)))]))
 
+    (define is-change-on-open
+      (new check-box%
+           [label "Change the current directory to the opened file when DrRacket launches."]
+           [parent experimental-tab]
+           [value (preferences:get 'files-viewer:change-on-open)]
+           [callback (λ (c e)
+                       (preferences:set 'files-viewer:change-on-open
+                                        (send is-change-on-open get-value)))]))
+
     (define (update-panels)
       (send tp change-children (λ (l)
                                  (match (send tp get-selection)
                                    [0 (list change-current-tab-to-a-new-file-when)]
-                                   [1 (list is-binary-file-open)]))))
+                                   [1 (list experimental-tab)]))))
     (update-panels)))
                                               
     


### PR DESCRIPTION
This commit adds a new (experimental) feature where the file viewer shows the directory of the file opened by DrRacket when it launches.

I frequently launch DrRacket from the command line with a specific file open, so immediately opening the files viewer on the directory of that file is useful to me. It might also be useful for others.

One quirk, currently, is that when DrRacket is launched as normal (i.e. without a file specified) it shows the home directory. Personally, I don't mind this, but it could be cumbersome to others.